### PR TITLE
[BACK-663] Migrate SendGrid authentication to api key

### DIFF
--- a/SendGrid.php
+++ b/SendGrid.php
@@ -2,18 +2,17 @@
 
 class SendGrid
 {
-  protected $namespace = "SendGrid",
-            $username,
-            $password;
+  protected $namespace = "SendGrid";
+  /** @var string Sendgrid API key. */
+  protected $apiKey;
 
   // Available transport mechanisms
   protected $web,
             $smtp;
   
-  public function __construct($username, $password)
+  public function __construct($apiKey)
   {
-    $this->username = $username;
-    $this->password = $password;
+    $this->apiKey = $apiKey;
   }
 
   public function __get($api)
@@ -35,8 +34,7 @@ class SendGrid
     }
     require_once $file;
 
-    $this->$name = new $api($this->username, $this->password);
+    $this->$name = new $api($this->apiKey);
     return $this->$name;
   }
-
 }

--- a/SendGrid/Api.php
+++ b/SendGrid/Api.php
@@ -4,14 +4,12 @@ namespace SendGrid;
 
 class Api
 {
-  
-  protected $username,
-            $password;
+  /** @var string Sendgrid API key with full 'Mail Send' permissions. */
+  protected $apiKey;
 
-  public function __construct($username, $password)
+  public function __construct($apiKey)
   {
-    $this->username = $username;
-    $this->password = $password;
+    $this->apiKey = $apiKey;
   }
 
 }

--- a/SendGrid/Smtp.php
+++ b/SendGrid/Smtp.php
@@ -7,8 +7,6 @@ namespace SendGrid;
  * Class Smtp
  * Send a SendGrid email using SendGrid's SMTP transport
  *
- * In production
- *
  * @package SendGrid
  */
 class Smtp extends Api implements MailInterface

--- a/SendGrid/Smtp.php
+++ b/SendGrid/Smtp.php
@@ -13,6 +13,7 @@ class Smtp extends Api implements MailInterface
   private $swift_instances = array();
   protected $port;
 
+  // TODO: Convert to API key
   public function __construct($username, $password)
   {
     require_once ROOT_DIR . 'lib/swift/swift_required.php';

--- a/SendGrid/Smtp.php
+++ b/SendGrid/Smtp.php
@@ -2,6 +2,15 @@
 
 namespace SendGrid;
 
+/**
+ * @deprecated
+ * Class Smtp
+ * Send a SendGrid email using SendGrid's SMTP transport
+ *
+ * In production
+ *
+ * @package SendGrid
+ */
 class Smtp extends Api implements MailInterface
 {
   //the available ports
@@ -13,8 +22,12 @@ class Smtp extends Api implements MailInterface
   private $swift_instances = array();
   protected $port;
 
-  // TODO: Convert to API key
-  public function __construct($username, $password)
+  /* SendGrid SMTP v2 API requires user_name to be set to 'apikey'.
+   * @see https://sendgrid.com/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys/
+   */
+  const USER_NAME = 'apikey';
+
+  public function __construct($apiKey)
   {
     require_once ROOT_DIR . 'lib/swift/swift_required.php';
     call_user_func_array("parent::__construct", func_get_args());
@@ -44,8 +57,8 @@ class Smtp extends Api implements MailInterface
     if (!isset($this->swift_instances[$port]))
     {
       $transport = \Swift_SmtpTransport::newInstance('smtp.sendgrid.net', $port);
-      $transport->setUsername($this->username);
-      $transport->setPassword($this->password);
+      $transport->setUsername(self::USER_NAME);
+      $transport->setPassword($this->apiKey);
 
       $swift = \Swift_Mailer::newInstance($transport);
 

--- a/SendGrid/Web.php
+++ b/SendGrid/Web.php
@@ -2,6 +2,14 @@
 
 namespace SendGrid;
 
+/**
+ * @deprecated
+ * Class Web
+ * Send an email through SendGrid using it's v2 API.
+ *
+ * @see https://www.twilio.com/docs/sendgrid/api/v2/mail#sending-email
+ * @package SendGrid
+ */
 class Web extends Api implements MailInterface
 {
 
@@ -122,8 +130,7 @@ class Web extends Api implements MailInterface
     $session = curl_init($request);
     curl_setopt ($session, CURLOPT_POST, true);
     curl_setopt ($session, CURLOPT_POSTFIELDS, $data);
-      curl_setopt($session, CURLOPT_HEADER, true);
-
+    curl_setopt($session, CURLOPT_HEADER, true);
     curl_setopt($session, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . $this->apiKey]);
     curl_setopt($session, CURLOPT_RETURNTRANSFER, true);
     //curl_setopt($session, CURLINFO_HEADER_OUT, true);

--- a/SendGrid/Web.php
+++ b/SendGrid/Web.php
@@ -12,35 +12,30 @@ class Web extends Api implements MailInterface
    * __construct
    * Create a new Web instance
    */
-  public function __construct($username, $password)
+  public function __construct($apiKey)
   {
     call_user_func_array("parent::__construct", func_get_args());
   }
 
   /**
-   * _prepMessageData
-   * Takes the mail message and returns a url friendly querystring
+   * Takes the mail message and returns query parameters for the SendGrid send mail request
    * @param  Mail   $mail [description]
-   * @return String - the data query string to be posted
+   * @return array Query parameters
    */
   protected function _prepMessageData(Mail $mail)
   {
-
     /* the api expects a 'to' parameter, but this parameter will be ignored
      * since we're sending the recipients through the header. The from
      * address will be used as a placeholder.
      */
-    $params =
-    array(
-      'api_user'  => $this->username,
-      'api_key'   => $this->password,
+    $params = [
       'subject'   => $mail->getSubject(),
       'html'      => $mail->getHtml(),
       'text'      => $mail->getText(),
       'from'      => $mail->getFrom(),
       'to'        => $mail->getFrom(),
       'x-smtpapi' => $mail->getHeadersJson()
-    );
+    ];
 
     if(($fromname = $mail->getFromName())) {
       $params['fromname'] = $fromname;
@@ -127,8 +122,9 @@ class Web extends Api implements MailInterface
     $session = curl_init($request);
     curl_setopt ($session, CURLOPT_POST, true);
     curl_setopt ($session, CURLOPT_POSTFIELDS, $data);
+      curl_setopt($session, CURLOPT_HEADER, true);
 
-    curl_setopt($session, CURLOPT_HEADER, false);
+    curl_setopt($session, CURLOPT_HTTPHEADER, ['Authorization: Bearer ' . $this->apiKey]);
     curl_setopt($session, CURLOPT_RETURNTRANSFER, true);
     //curl_setopt($session, CURLINFO_HEADER_OUT, true);
 


### PR DESCRIPTION
## Goal
Change SendGrid authentication from username/password to API key.

The Web repo is on the 'http-api-update' branch, which is significantly behind master. :see_no_evil: :hear_no_evil: :speak_no_evil: 

## Reference
Jira ticket:
- https://getpocket.atlassian.net/browse/BACK-663

Web repo PR:
- https://github.com/Pocket/Web/pull/4088